### PR TITLE
Remove mime-types dependency

### DIFF
--- a/carrierwave-meta.gemspec
+++ b/carrierwave-meta.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<carrierwave>, [">= 0.5.7"])
   s.add_dependency(%q<activesupport>, [">= 3.0"])
-  s.add_dependency(%q<mime-types>)
   s.add_development_dependency(%q<rspec-rails>, ">= 2.6")
   s.add_development_dependency(%q<sqlite3-ruby>)
   s.add_development_dependency(%q<rmagick>)


### PR DESCRIPTION
Because carrierwave already has mime-types dependency, we don't need to
provide this dependency in this gem
